### PR TITLE
Update cmake_build.yml

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -60,12 +60,12 @@ jobs:
           generator: Xcode
 
         - name: Windows_32bit
-          os: windows-latest
+          os: windows-2019
           arch: 32bit # as reported by Windows Settings > System > About
           generator: Visual Studio 16 2019
 
         - name: Windows_64bit
-          os: windows-latest
+          os: windows-2019
           arch: 64bit # as reported by Windows Settings > System > About
           generator: Visual Studio 16 2019
 


### PR DESCRIPTION
Should set to windows 2019 and VS-2019 image for CI workflow.