### PR TITLE
changed the generator to use vs 2022

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -62,12 +62,12 @@ jobs:
         - name: Windows_32bit
           os: windows-latest
           arch: 32bit # as reported by Windows Settings > System > About
-          generator: Visual Studio 16 2019
+          generator: Visual Studio 17 2022
 
         - name: Windows_64bit
           os: windows-latest
           arch: 64bit # as reported by Windows Settings > System > About
-          generator: Visual Studio 16 2019
+          generator: Visual Studio 17 2022
 
     steps:
 


### PR DESCRIPTION
Resolves: ci breaking while using msvc

i changed the cmake build file so as to use vs 2022 instead of vs 2019

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I made sure the code compiles on my machine.
- [x] I made sure there are no unnecessary changes in the code.
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving.
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?".
- [x] I hereby reaffirm that I am licensing my contribution under the GNU General Public License v2.0 or later (`GPL-2.0-or-later`).
